### PR TITLE
Fix translation page link

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -570,7 +570,7 @@ http://sourceforge.net/blog/projects-of-the-week-february-16-2015">Featured Proj
 		<p>You do not necessarily have to be a programmer to help and make TeXstudio even better. There are many ways to contribute.</p>
 		<ul>
 		<li>Write cwl-files for your favorite package.</li>
-		<li><a href="https://www.transifex.com/texstudio/texstudio/">Translate</a> TeXstudio into a new language or update an existing translation.</li>
+		<li><a href="https://app.transifex.com/texstudio/texstudio/dashboard/">Translate</a> TeXstudio into a new language or update an existing translation.</li>
 		<li>Design icons.</li>
 		<li>Help on improving our website.</li>
 		<li>Update or extend the <a href="https://texstudio-org.github.io/getting_started.html">user manual</a> or the <a href="https://github.com/texstudio-org/texstudio/wiki">wiki</a>.</li>


### PR DESCRIPTION
This is the same link as is used in https://github.com/texstudio-org/texstudio/wiki/Contribute. The old link leads to a 404.